### PR TITLE
Added a Symlink so I can have Vim Autocompletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,3 @@ cmake-build-debug
 *_REMOTE_*.txt
 *.orig
 
-# Symbols database for stuff like autocomplete in Vim
-compile_commands.json
-

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,0 +1,1 @@
+build/compile_commands.json


### PR DESCRIPTION
Basically, if you run the command `catkin_make -DCMAKE_COMPILE_COMMANDS=1`, `CMake` will nicely generate the `build/compile_commands.json` file for you. I've added a symlink to this so that when I open vim in the project and it searches upwards for the `compile_commands.json` file, it hits the symlink at the root of the repo. 

**TLDR:** I'm being selfish and want my Vim autocompletion