### PR TITLE
 Updated the formatting script to have a default branch 

### DIFF
--- a/clang-format/fix_formatting.sh
+++ b/clang-format/fix_formatting.sh
@@ -1,17 +1,34 @@
 #!/bin/bash
 
+# This script can be called with no arguments (`./fix_formatting`), in which 
+# case DEFAULT_BRANCH will be used as the branch to compare against to find 
+# changes to format, or it can be called with a specific branch to compare 
+# against (`./fix_formatting master`)
+
 # The version of the clang executable to use
-export CLANG_VERSION=4.0
+CLANG_VERSION=4.0
+
+# The default branch to compare against
+DEFAULT_BRANCH="master"
 
 # The current directory
 CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Check that we got exactly one argument
-if [ "$#" -ne 1 ]; then
-    echo "This program takes 1 argument (the name of the branch to compare against)."
+# Check for arguments
+if [ "$#" -eq 1 ]; then
+    # If there is one arg, then that is the target branch to compare against
+    # (to figure out what changes were made and need to be formatted)
+    TARGET_BRANCH=$1
+elif [ "$#" -eq 0 ]; then
+    # If there are no args, then just compare against the default branch 
+    # (to figure out what changes were made and need to be formatted)
+    TARGET_BRANCH=$DEFAULT_BRANCH
+else
+    echo "This program takes at most one argument"
+    echo "If one argument is given, it will be treated as the name of the branch to compare against to find changes to format"
+    echo "If no arguments are given, then the default branch (currently: $DEFAULT_BRANCH) will be used"
     exit 1
 fi
-TARGET_BRANCH=$1
 
 # Fix formatting on all changes between this branch and the target branch
 OUTPUT="$($CURR_DIR/git-clang-format --binary $CURR_DIR/clang-format-$CLANG_VERSION --commit $TARGET_BRANCH)"

--- a/clang-format/fix_formatting.sh
+++ b/clang-format/fix_formatting.sh
@@ -11,7 +11,8 @@ CLANG_VERSION=4.0
 # The default branch to compare against
 DEFAULT_BRANCH="master"
 
-# The current directory
+# The directory that this script is in (NOT the directory that this script is run from)
+# This allows us to find files relative to this script
 CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Check for arguments


### PR DESCRIPTION
@RobynCastro - I figured this is a good opportunity to learn some more about how the all the automated formatting stuff works. ~The only change here is the `fix_formatting.sh` file, the rest of the diff is because I branched off the changes from #259 to avoid future conflicts (that also means this PR is blocked on #259).~ Lemme know if you have questions about how the whole clang-format thing works.
  