### PR TITLE
Added missing variable "CLANG_VERSION" into travis_ci.sh

### DIFF
--- a/travis_ci.sh
+++ b/travis_ci.sh
@@ -45,6 +45,7 @@ if [ "$RUN_TESTS" == "true" ]; then
 fi
 
 if [ "$RUN_FORMATTING_CHECKS" == "true" ]; then
+    CLANG_VERSION="4.0"
     # Determine what we should compare this branch against to figure out what 
     # files were changed
     if [ "$TRAVIS_PULL_REQUEST" == "false" ] ; then


### PR DESCRIPTION
Looks like this was causing all formatting checks to fail, I'm not sure how I was able to sneak this one past in #283..... 