### PR TITLE
Changed most packages to build in Release instead of Debug by default

### DIFF
--- a/src/decision_igvc/CMakeLists.txt
+++ b/src/decision_igvc/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(decision_igvc)
 
+# Build in "Release" (with lots of compiler optimizations) by default
+# (If built in "Debug", some functions can take orders of magnitude longer)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+endif()
+
 add_definitions(--std=c++14)
 
 ## Find catkin macros and libraries

--- a/src/drag_race_iarrc/CMakeLists.txt
+++ b/src/drag_race_iarrc/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(drag_race_iarrc)
 
+# Build in "Release" (with lots of compiler optimizations) by default
+# (If built in "Debug", some functions can take orders of magnitude longer)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+endif()
+
 # This exports the compile commands so people using Vim with YouCompleteMe
 # can have easy autocompletion
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/src/mapping_igvc/CMakeLists.txt
+++ b/src/mapping_igvc/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mapping_igvc)
 
+# Build in "Release" (with lots of compiler optimizations) by default
+# (If built in "Debug", some functions can take orders of magnitude longer)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+endif()
+
 add_definitions(--std=c++14)
 
 ## Find catkin macros and libraries

--- a/src/pathfinding_igvc/CMakeLists.txt
+++ b/src/pathfinding_igvc/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(pathfinding_igvc)
 
+# Build in "Release" (with lots of compiler optimizations) by default
+# (If built in "Debug", some functions can take orders of magnitude longer)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+endif()
+
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS roscpp)
 find_package(sb_utils REQUIRED)

--- a/src/sample_package/CMakeLists.txt
+++ b/src/sample_package/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(sample_package)
 
+# Build in "Release" (with lots of compiler optimizations) by default
+# (If built in "Debug", some functions can take orders of magnitude longer)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+endif()
+
+add_definitions(-std=c++14)
+
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
@@ -9,8 +17,6 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
 )
 find_package(sb_utils REQUIRED)
-
-add_definitions(-std=c++14)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/src/sb_pointcloud_processing/CMakeLists.txt
+++ b/src/sb_pointcloud_processing/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(sb_pointcloud_processing)
 
+# Build in "Release" (with lots of compiler optimizations) by default
+# (If built in "Debug", some functions can take orders of magnitude longer)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+endif()
+
 add_definitions(-std=c++14)
 
 ## Find catkin macros and libraries

--- a/src/sb_utils/CMakeLists.txt
+++ b/src/sb_utils/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(sb_utils)
 
+# Build in "Release" (with lots of compiler optimizations) by default
+# (If built in "Debug", some functions can take orders of magnitude longer)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+endif()
+
 add_definitions(-std=c++14)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/src/sb_vision/CMakeLists.txt
+++ b/src/sb_vision/CMakeLists.txt
@@ -1,12 +1,18 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(sb_vision)
 
+# Build in "Release" (with lots of compiler optimizations) by default
+# (If built in "Debug", some functions can take orders of magnitude longer)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+endif()
+
+add_definitions(-std=c++14)
+
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS roscpp rospy cv_bridge image_transport )
 find_package(OpenCV REQUIRED)
 find_package(sb_utils REQUIRED)
-
-add_definitions(-std=c++14)
 
 catkin_package(
     #  INCLUDE_DIRS include


### PR DESCRIPTION
Modified the `CMakeLists.txt` for most projects so that they build in `Release` instead of `Debug` by default. This will likely make several sections of the codebase (notably anything intensive like vision or pointcloud processing) run much faster.