### PR TITLE
Fix path constructor melodic

### DIFF
--- a/src/pathfinding_igvc/include/PathConstructor.h
+++ b/src/pathfinding_igvc/include/PathConstructor.h
@@ -26,7 +26,7 @@ class PathConstructor {
      * @param occupancy_grid_adapter
      * @return PathConstructor
      */
-    PathConstructor(OccupancyGridAdapter occupancy_grid_adapter);
+    PathConstructor(OccupancyGridAdapter *occupancy_grid_adapter);
 
     /**
      * Takes in a stack of GridPoints and returns a path

--- a/src/pathfinding_igvc/include/PathConstructor.h
+++ b/src/pathfinding_igvc/include/PathConstructor.h
@@ -13,7 +13,7 @@
 #include <OccupancyGridAdapter.h>
 
 class PathConstructor {
-    OccupancyGridAdapter* _occupancy_grid_adapter;
+    std::shared_ptr<OccupancyGridAdapter> _occupancy_grid_adapter;
 
   public:
     /**
@@ -26,7 +26,7 @@ class PathConstructor {
      * @param occupancy_grid_adapter
      * @return PathConstructor
      */
-    PathConstructor(OccupancyGridAdapter *occupancy_grid_adapter);
+    PathConstructor(std::shared_ptr<OccupancyGridAdapter> occupancy_grid_adapter_ptr);
 
     /**
      * Takes in a stack of GridPoints and returns a path

--- a/src/pathfinding_igvc/include/PathConstructor.h
+++ b/src/pathfinding_igvc/include/PathConstructor.h
@@ -26,7 +26,8 @@ class PathConstructor {
      * @param occupancy_grid_adapter
      * @return PathConstructor
      */
-    PathConstructor(std::shared_ptr<OccupancyGridAdapter> occupancy_grid_adapter_ptr);
+    PathConstructor(
+    std::shared_ptr<OccupancyGridAdapter> occupancy_grid_adapter_ptr);
 
     /**
      * Takes in a stack of GridPoints and returns a path

--- a/src/pathfinding_igvc/src/PathConstructor.cpp
+++ b/src/pathfinding_igvc/src/PathConstructor.cpp
@@ -6,8 +6,8 @@
 
 #include <PathConstructor.h>
 
-PathConstructor::PathConstructor(OccupancyGridAdapter *occupancy_grid_adapter) {
-    this->_occupancy_grid_adapter = occupancy_grid_adapter;
+PathConstructor::PathConstructor(std::shared_ptr<OccupancyGridAdapter> occupancy_grid_adapter_ptr) {
+    this->_occupancy_grid_adapter = occupancy_grid_adapter_ptr;
 }
 
 nav_msgs::Path

--- a/src/pathfinding_igvc/src/PathConstructor.cpp
+++ b/src/pathfinding_igvc/src/PathConstructor.cpp
@@ -6,7 +6,8 @@
 
 #include <PathConstructor.h>
 
-PathConstructor::PathConstructor(std::shared_ptr<OccupancyGridAdapter> occupancy_grid_adapter_ptr) {
+PathConstructor::PathConstructor(
+std::shared_ptr<OccupancyGridAdapter> occupancy_grid_adapter_ptr) {
     this->_occupancy_grid_adapter = occupancy_grid_adapter_ptr;
 }
 
@@ -17,7 +18,8 @@ PathConstructor::constructPath(std::stack<AStar::GridPoint> grid_points) {
     while (!grid_points.empty()) {
         AStar::GridPoint current_grid_point = grid_points.top();
         geometry_msgs::Point current_map_point =
-        this->_occupancy_grid_adapter->convertFromGridToMapPoint(current_grid_point);
+        this->_occupancy_grid_adapter->convertFromGridToMapPoint(
+        current_grid_point);
         grid_points.pop();
 
         double angle = 0.0;
@@ -25,9 +27,9 @@ PathConstructor::constructPath(std::stack<AStar::GridPoint> grid_points) {
             AStar::GridPoint next_grid_point = grid_points.top();
             geometry_msgs::Point next_map_point =
             this->_occupancy_grid_adapter->convertFromGridToMapPoint(
-                    next_grid_point);
-            angle =
-            PathFinderUtils::getAngleBetweenPoints(current_map_point, next_map_point);
+            next_grid_point);
+            angle = PathFinderUtils::getAngleBetweenPoints(current_map_point,
+                                                           next_map_point);
         }
 
         geometry_msgs::PoseStamped pose_stamped =

--- a/src/pathfinding_igvc/src/PathConstructor.cpp
+++ b/src/pathfinding_igvc/src/PathConstructor.cpp
@@ -6,30 +6,32 @@
 
 #include <PathConstructor.h>
 
-PathConstructor::PathConstructor(OccupancyGridAdapter occupancy_grid_adapter) {
-    this->_occupancy_grid_adapter = &occupancy_grid_adapter;
+PathConstructor::PathConstructor(OccupancyGridAdapter *occupancy_grid_adapter) {
+    this->_occupancy_grid_adapter = occupancy_grid_adapter;
 }
 
 nav_msgs::Path
-PathConstructor::constructPath(std::stack<AStar::GridPoint> points) {
+PathConstructor::constructPath(std::stack<AStar::GridPoint> grid_points) {
     nav_msgs::Path path;
 
-    while (!points.empty()) {
-        geometry_msgs::Point current_point =
-        this->_occupancy_grid_adapter->convertFromGridToMapPoint(points.top());
-        points.pop();
+    while (!grid_points.empty()) {
+        AStar::GridPoint current_grid_point = grid_points.top();
+        geometry_msgs::Point current_map_point =
+        this->_occupancy_grid_adapter->convertFromGridToMapPoint(current_grid_point);
+        grid_points.pop();
 
         double angle = 0.0;
-        if (!points.empty()) {
-            geometry_msgs::Point next_point =
+        if (!grid_points.empty()) {
+            AStar::GridPoint next_grid_point = grid_points.top();
+            geometry_msgs::Point next_map_point =
             this->_occupancy_grid_adapter->convertFromGridToMapPoint(
-            points.top());
+                    next_grid_point);
             angle =
-            PathFinderUtils::getAngleBetweenPoints(current_point, next_point);
+            PathFinderUtils::getAngleBetweenPoints(current_map_point, next_map_point);
         }
 
         geometry_msgs::PoseStamped pose_stamped =
-        PathFinderUtils::constructPoseStamped(current_point, angle);
+        PathFinderUtils::constructPoseStamped(current_map_point, angle);
         path.poses.push_back(pose_stamped);
     }
 

--- a/src/pathfinding_igvc/src/PathFinder.cpp
+++ b/src/pathfinding_igvc/src/PathFinder.cpp
@@ -21,8 +21,8 @@ nav_msgs::Path PathFinder::calculatePath(geometry_msgs::Point start,
 
     std::stack<AStar::GridPoint> points =
     AStar::run(grid, start_on_grid, goal_on_grid);
-    OccupancyGridAdapter *occupancy_grid_adapter = new OccupancyGridAdapter(grid.info);
-    return PathConstructor(occupancy_grid_adapter)
+    std::shared_ptr<OccupancyGridAdapter> occupancy_grid_adapter_ptr(new OccupancyGridAdapter(grid.info));
+    return PathConstructor(occupancy_grid_adapter_ptr)
     .constructPath(points);
 }
 

--- a/src/pathfinding_igvc/src/PathFinder.cpp
+++ b/src/pathfinding_igvc/src/PathFinder.cpp
@@ -21,9 +21,9 @@ nav_msgs::Path PathFinder::calculatePath(geometry_msgs::Point start,
 
     std::stack<AStar::GridPoint> points =
     AStar::run(grid, start_on_grid, goal_on_grid);
-    std::shared_ptr<OccupancyGridAdapter> occupancy_grid_adapter_ptr(new OccupancyGridAdapter(grid.info));
-    return PathConstructor(occupancy_grid_adapter_ptr)
-    .constructPath(points);
+    std::shared_ptr<OccupancyGridAdapter> occupancy_grid_adapter_ptr(
+    new OccupancyGridAdapter(grid.info));
+    return PathConstructor(occupancy_grid_adapter_ptr).constructPath(points);
 }
 
 void PathFinder::processGridAndGetStartAndGoalOnGrid(

--- a/src/pathfinding_igvc/src/PathFinder.cpp
+++ b/src/pathfinding_igvc/src/PathFinder.cpp
@@ -21,7 +21,8 @@ nav_msgs::Path PathFinder::calculatePath(geometry_msgs::Point start,
 
     std::stack<AStar::GridPoint> points =
     AStar::run(grid, start_on_grid, goal_on_grid);
-    return PathConstructor(OccupancyGridAdapter(grid.info))
+    OccupancyGridAdapter *occupancy_grid_adapter = new OccupancyGridAdapter(grid.info);
+    return PathConstructor(occupancy_grid_adapter)
     .constructPath(points);
 }
 

--- a/src/pathfinding_igvc/test/occupancy-grid-adapter-test.cpp
+++ b/src/pathfinding_igvc/test/occupancy-grid-adapter-test.cpp
@@ -41,7 +41,7 @@ TEST(OccupancyGridAdapter, TestConvertFromMapToGridPoint) {
     /* origin of OccupancyGrid */
     // initialize origin of occupancy grid
     geometry_msgs::Pose origin =
-            PathFinderTestUtils::constructPose(3.0, 3.0, 0.0);
+    PathFinderTestUtils::constructPose(3.0, 3.0, 0.0);
 
     /* mapMetaData of OccupancyGrid */
     // initialize mapMetaData

--- a/src/pathfinding_igvc/test/occupancy-grid-adapter-test.cpp
+++ b/src/pathfinding_igvc/test/occupancy-grid-adapter-test.cpp
@@ -54,15 +54,12 @@ TEST(OccupancyGridAdapter, TestConvertFromMapToGridPoint) {
 
     /* OccupancyGridAdapter */
     OccupancyGridAdapter adapter = OccupancyGridAdapter(map_meta_data);
-
-    AStar::GridPoint point;
-    point.col = 3;
-    point.row = 2;
+    AStar::GridPoint point(-99, -99);
 
     geometry_msgs::Point map_point = adapter.convertFromGridToMapPoint(point);
 
-    EXPECT_FLOAT_EQ(map_point.x, 3.0 + 3 * 2);
-    EXPECT_FLOAT_EQ(map_point.y, 3.0 + 2 * 2);
+    EXPECT_FLOAT_EQ(map_point.x, 3.0 - 99 * 2);
+    EXPECT_FLOAT_EQ(map_point.y, 3.0 - 99 * 2);
 }
 
 int main(int argc, char** argv) {

--- a/src/pathfinding_igvc/test/occupancy-grid-adapter-test.cpp
+++ b/src/pathfinding_igvc/test/occupancy-grid-adapter-test.cpp
@@ -37,6 +37,34 @@ TEST(OccupancyGridAdapter, TestIndexOfPointInGrid) {
     EXPECT_EQ(grid_point.row, 0);
 }
 
+TEST(OccupancyGridAdapter, TestConvertFromMapToGridPoint) {
+    /* origin of OccupancyGrid */
+    // initialize origin of occupancy grid
+    geometry_msgs::Pose origin =
+            PathFinderTestUtils::constructPose(3.0, 3.0, 0.0);
+
+    /* mapMetaData of OccupancyGrid */
+    // initialize mapMetaData
+    nav_msgs::MapMetaData map_meta_data;
+    map_meta_data.resolution = 2.0;
+    map_meta_data.width      = 2;
+    map_meta_data.height     = 2;
+    // add origin to mapMetaData
+    map_meta_data.origin = origin;
+
+    /* OccupancyGridAdapter */
+    OccupancyGridAdapter adapter = OccupancyGridAdapter(map_meta_data);
+
+    AStar::GridPoint point;
+    point.col = 3;
+    point.row = 2;
+
+    geometry_msgs::Point map_point = adapter.convertFromGridToMapPoint(point);
+
+    EXPECT_FLOAT_EQ(map_point.x, 3.0 + 3 * 2);
+    EXPECT_FLOAT_EQ(map_point.y, 3.0 + 2 * 2);
+}
+
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/src/pathfinding_igvc/test/path-constructor-test.cpp
+++ b/src/pathfinding_igvc/test/path-constructor-test.cpp
@@ -9,47 +9,51 @@
 #include <gtest/gtest.h>
 
 // TODO: Uncomment and fix, see issue #339
-// TEST(PathConstructor, TestConstructPath) {
-//    /* origin of OccupancyGrid */
-//    // initialize origin of occupancy grid
-//    geometry_msgs::Pose origin =
-//    PathFinderTestUtils::constructPose(3.0, 3.0, 0.0);
-//
-//    /* mapMetaData of OccupancyGrid */
-//    // initialize mapMetaData
-//    nav_msgs::MapMetaData map_meta_data;
-//    map_meta_data.resolution = 2.0;
-//    map_meta_data.width      = 2;
-//    map_meta_data.height     = 2;
-//    // add origin to mapMetaData
-//    map_meta_data.origin = origin;
-//
-//    /* OccupancyGridAdapter */
-//    OccupancyGridAdapter occupancy_grid_adapter =
-//    OccupancyGridAdapter(map_meta_data);
-//
-//    /* first point in path*/
-//    AStar::GridPoint point1(-99 - sqrt(3), -99 - 1);
-//
-//    /* second point in path*/
-//    AStar::GridPoint point2(-99, -99);
-//
-//    /* add points to path */
-//    std::stack<AStar::GridPoint> points;
-//    points.push(point1);
-//    points.push(point2);
-//
-//    nav_msgs::Path path =
-//    PathConstructor(occupancy_grid_adapter).constructPath(points);
-//
-//    tf::Quaternion q1;
-//    tf::quaternionMsgToTF(path.poses[0].pose.orientation, q1);
-//
-//    /* we lose resolution by converting a point into a grid, so allow more
-//    error
-//     */
-//    EXPECT_NEAR(q1.getAngle(), M_PI + M_PI / 6, 0.5);
-//}
+ TEST(PathConstructor, TestConstructPath) {
+    /* origin of OccupancyGrid */
+    // initialize origin of occupancy grid
+    geometry_msgs::Pose origin =
+    PathFinderTestUtils::constructPose(3.0, 3.0, 0.0);
+
+    /* mapMetaData of OccupancyGrid */
+    // initialize mapMetaData
+    nav_msgs::MapMetaData map_meta_data;
+    map_meta_data.resolution = 2.0;
+    map_meta_data.width      = 2;
+    map_meta_data.height     = 2;
+    // add origin to mapMetaData
+    map_meta_data.origin = origin;
+
+    /* OccupancyGridAdapter */
+    OccupancyGridAdapter *occupancy_grid_adapter =
+    new OccupancyGridAdapter(map_meta_data);
+
+    /* first point in path*/
+    AStar::GridPoint point1(-99 - sqrt(3), -99 - 1);
+
+    /* second point in path*/
+    AStar::GridPoint point2(-99, -99);
+
+    /* add points to path */
+    std::stack<AStar::GridPoint> points;
+    points.push(point1);
+    points.push(point2);
+
+    PathConstructor path_constructor(occupancy_grid_adapter);
+    nav_msgs::Path path = path_constructor.constructPath(points);
+
+    tf::Quaternion q1;
+    tf::quaternionMsgToTF(path.poses[0].pose.orientation, q1);
+
+    /* we lose resolution by converting a point into a grid, so allow more
+    error
+     */
+    EXPECT_NEAR(q1.getAngle(), M_PI + M_PI / 6, 0.5);
+    EXPECT_FLOAT_EQ(path.poses[0].pose.position.x, occupancy_grid_adapter->convertFromGridToMapPoint(point2).x);
+    EXPECT_FLOAT_EQ(path.poses[0].pose.position.y, occupancy_grid_adapter->convertFromGridToMapPoint(point2).y);
+    EXPECT_FLOAT_EQ(path.poses[1].pose.position.x, occupancy_grid_adapter->convertFromGridToMapPoint(point1).x);
+    EXPECT_FLOAT_EQ(path.poses[1].pose.position.y, occupancy_grid_adapter->convertFromGridToMapPoint(point1).y);
+}
 
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);

--- a/src/pathfinding_igvc/test/path-constructor-test.cpp
+++ b/src/pathfinding_igvc/test/path-constructor-test.cpp
@@ -9,7 +9,7 @@
 #include <gtest/gtest.h>
 
 // TODO: Uncomment and fix, see issue #339
- TEST(PathConstructor, TestConstructPath) {
+TEST(PathConstructor, TestConstructPath) {
     /* origin of OccupancyGrid */
     // initialize origin of occupancy grid
     geometry_msgs::Pose origin =
@@ -25,7 +25,8 @@
     map_meta_data.origin = origin;
 
     /* OccupancyGridAdapter */
-    std::shared_ptr<OccupancyGridAdapter> occupancy_grid_adapter_ptr(new OccupancyGridAdapter(map_meta_data));
+    std::shared_ptr<OccupancyGridAdapter> occupancy_grid_adapter_ptr(
+    new OccupancyGridAdapter(map_meta_data));
 
     /* first point in path*/
     AStar::GridPoint point1(-99 - sqrt(3), -99 - 1);
@@ -48,10 +49,18 @@
     error
      */
     EXPECT_NEAR(q1.getAngle(), M_PI + M_PI / 6, 0.5);
-    EXPECT_FLOAT_EQ(path.poses[0].pose.position.x, occupancy_grid_adapter_ptr->convertFromGridToMapPoint(point2).x);
-    EXPECT_FLOAT_EQ(path.poses[0].pose.position.y, occupancy_grid_adapter_ptr->convertFromGridToMapPoint(point2).y);
-    EXPECT_FLOAT_EQ(path.poses[1].pose.position.x, occupancy_grid_adapter_ptr->convertFromGridToMapPoint(point1).x);
-    EXPECT_FLOAT_EQ(path.poses[1].pose.position.y, occupancy_grid_adapter_ptr->convertFromGridToMapPoint(point1).y);
+    EXPECT_FLOAT_EQ(
+    path.poses[0].pose.position.x,
+    occupancy_grid_adapter_ptr->convertFromGridToMapPoint(point2).x);
+    EXPECT_FLOAT_EQ(
+    path.poses[0].pose.position.y,
+    occupancy_grid_adapter_ptr->convertFromGridToMapPoint(point2).y);
+    EXPECT_FLOAT_EQ(
+    path.poses[1].pose.position.x,
+    occupancy_grid_adapter_ptr->convertFromGridToMapPoint(point1).x);
+    EXPECT_FLOAT_EQ(
+    path.poses[1].pose.position.y,
+    occupancy_grid_adapter_ptr->convertFromGridToMapPoint(point1).y);
 }
 
 int main(int argc, char** argv) {

--- a/src/pathfinding_igvc/test/path-constructor-test.cpp
+++ b/src/pathfinding_igvc/test/path-constructor-test.cpp
@@ -25,8 +25,7 @@
     map_meta_data.origin = origin;
 
     /* OccupancyGridAdapter */
-    OccupancyGridAdapter *occupancy_grid_adapter =
-    new OccupancyGridAdapter(map_meta_data);
+    std::shared_ptr<OccupancyGridAdapter> occupancy_grid_adapter_ptr(new OccupancyGridAdapter(map_meta_data));
 
     /* first point in path*/
     AStar::GridPoint point1(-99 - sqrt(3), -99 - 1);
@@ -39,7 +38,7 @@
     points.push(point1);
     points.push(point2);
 
-    PathConstructor path_constructor(occupancy_grid_adapter);
+    PathConstructor path_constructor(occupancy_grid_adapter_ptr);
     nav_msgs::Path path = path_constructor.constructPath(points);
 
     tf::Quaternion q1;
@@ -49,10 +48,10 @@
     error
      */
     EXPECT_NEAR(q1.getAngle(), M_PI + M_PI / 6, 0.5);
-    EXPECT_FLOAT_EQ(path.poses[0].pose.position.x, occupancy_grid_adapter->convertFromGridToMapPoint(point2).x);
-    EXPECT_FLOAT_EQ(path.poses[0].pose.position.y, occupancy_grid_adapter->convertFromGridToMapPoint(point2).y);
-    EXPECT_FLOAT_EQ(path.poses[1].pose.position.x, occupancy_grid_adapter->convertFromGridToMapPoint(point1).x);
-    EXPECT_FLOAT_EQ(path.poses[1].pose.position.y, occupancy_grid_adapter->convertFromGridToMapPoint(point1).y);
+    EXPECT_FLOAT_EQ(path.poses[0].pose.position.x, occupancy_grid_adapter_ptr->convertFromGridToMapPoint(point2).x);
+    EXPECT_FLOAT_EQ(path.poses[0].pose.position.y, occupancy_grid_adapter_ptr->convertFromGridToMapPoint(point2).y);
+    EXPECT_FLOAT_EQ(path.poses[1].pose.position.x, occupancy_grid_adapter_ptr->convertFromGridToMapPoint(point1).x);
+    EXPECT_FLOAT_EQ(path.poses[1].pose.position.y, occupancy_grid_adapter_ptr->convertFromGridToMapPoint(point1).y);
 }
 
 int main(int argc, char** argv) {

--- a/src/pathfinding_igvc/test/path-finder-test.cpp
+++ b/src/pathfinding_igvc/test/path-finder-test.cpp
@@ -12,7 +12,7 @@ signed char _ = AStar::GRID_FREE;
 signed char X = AStar::GRID_OCCUPIED;
 
 // TODO: Uncomment and fix, see issue #339
- TEST(PathFinder, TestPathWithNoObstacle) {
+TEST(PathFinder, TestPathWithNoObstacle) {
     /* origin of OccupancyGrid */
     // initialize origin of occupancy grid
     geometry_msgs::Pose origin =
@@ -54,7 +54,7 @@ signed char X = AStar::GRID_OCCUPIED;
 }
 
 // TODO: Uncomment and fix, see issue #339
- TEST(PathFinder, TestFullPath) {
+TEST(PathFinder, TestFullPath) {
     /* origin of OccupancyGrid */
     // initialize origin of occupancy grid
     geometry_msgs::Pose origin =
@@ -104,7 +104,7 @@ signed char X = AStar::GRID_OCCUPIED;
 }
 
 // TODO: Uncomment and fix, see issue #339
- TEST(PathFinder, PathFindingWhenGoalNotInGrid) {
+TEST(PathFinder, PathFindingWhenGoalNotInGrid) {
     /* origin of OccupancyGrid */
     // initialize origin of occupancy grid
     geometry_msgs::Pose origin =

--- a/src/pathfinding_igvc/test/path-finder-test.cpp
+++ b/src/pathfinding_igvc/test/path-finder-test.cpp
@@ -12,143 +12,143 @@ signed char _ = AStar::GRID_FREE;
 signed char X = AStar::GRID_OCCUPIED;
 
 // TODO: Uncomment and fix, see issue #339
-// TEST(PathFinder, TestPathWithNoObstacle) {
-//    /* origin of OccupancyGrid */
-//    // initialize origin of occupancy grid
-//    geometry_msgs::Pose origin =
-//    PathFinderTestUtils::constructPose(3.0, 3.0, 0.0);
-//
-//    /* mapMetaData of OccupancyGrid */
-//    // initialize mapMetaData
-//    nav_msgs::MapMetaData mapMetaData;
-//    mapMetaData.resolution = 2.0;
-//    mapMetaData.width      = 2;
-//    mapMetaData.height     = 2;
-//    // add origin to mapMetaData
-//    mapMetaData.origin = origin;
-//
-//    /* OccupancyGrid */
-//    // initialize occupancy grid
-//    nav_msgs::OccupancyGrid grid;
-//
-//    // set mapMetaData
-//    grid.info = mapMetaData;
-//    grid.data = std::vector<int8_t>(4, _);
-//
-//    geometry_msgs::Point start;
-//    start.x = 3.0;
-//    start.y = 3.0;
-//    geometry_msgs::Point goal;
-//    goal.x = 5.0;
-//    goal.y = 5.0;
-//
-//    nav_msgs::Path path = PathFinder::calculatePath(start, goal, grid);
-//
-//    ASSERT_EQ(path.poses.size(), 2);
-//
-//    EXPECT_FLOAT_EQ(path.poses[0].pose.position.x, 3.0);
-//    EXPECT_FLOAT_EQ(path.poses[0].pose.position.y, 3.0);
-//
-//    EXPECT_FLOAT_EQ(path.poses[1].pose.position.x, 5.0);
-//    EXPECT_FLOAT_EQ(path.poses[1].pose.position.y, 5.0);
-//}
+ TEST(PathFinder, TestPathWithNoObstacle) {
+    /* origin of OccupancyGrid */
+    // initialize origin of occupancy grid
+    geometry_msgs::Pose origin =
+    PathFinderTestUtils::constructPose(3.0, 3.0, 0.0);
+
+    /* mapMetaData of OccupancyGrid */
+    // initialize mapMetaData
+    nav_msgs::MapMetaData mapMetaData;
+    mapMetaData.resolution = 2.0;
+    mapMetaData.width      = 2;
+    mapMetaData.height     = 2;
+    // add origin to mapMetaData
+    mapMetaData.origin = origin;
+
+    /* OccupancyGrid */
+    // initialize occupancy grid
+    nav_msgs::OccupancyGrid grid;
+
+    // set mapMetaData
+    grid.info = mapMetaData;
+    grid.data = std::vector<int8_t>(4, _);
+
+    geometry_msgs::Point start;
+    start.x = 3.0;
+    start.y = 3.0;
+    geometry_msgs::Point goal;
+    goal.x = 5.0;
+    goal.y = 5.0;
+
+    nav_msgs::Path path = PathFinder::calculatePath(start, goal, grid);
+
+    ASSERT_EQ(path.poses.size(), 2);
+
+    EXPECT_FLOAT_EQ(path.poses[0].pose.position.x, 3.0);
+    EXPECT_FLOAT_EQ(path.poses[0].pose.position.y, 3.0);
+
+    EXPECT_FLOAT_EQ(path.poses[1].pose.position.x, 5.0);
+    EXPECT_FLOAT_EQ(path.poses[1].pose.position.y, 5.0);
+}
 
 // TODO: Uncomment and fix, see issue #339
-// TEST(PathFinder, TestFullPath) {
-//    /* origin of OccupancyGrid */
-//    // initialize origin of occupancy grid
-//    geometry_msgs::Pose origin =
-//    PathFinderTestUtils::constructPose(0.0, 0.0, 0.0);
-//
-//    /* mapMetaData of OccupancyGrid */
-//    // initialize mapMetaData
-//    nav_msgs::MapMetaData mapMetaData;
-//    mapMetaData.resolution = 1.0;
-//    mapMetaData.width      = 10;
-//    mapMetaData.height     = 9;
-//    // add origin to mapMetaData
-//    mapMetaData.origin = origin;
-//
-//    /* OccupancyGrid */
-//    // initialize occupancy grid
-//    nav_msgs::OccupancyGrid grid;
-//
-//    // set mapMetaData
-//    grid.info = mapMetaData;
-//    grid.data = {_, _, _, X, X, X, _, X, X, _, _, X, _, _, _, _, X, _,
-//                 _, _, _, X, X, X, X, _, X, X, X, _, _, X, _, _, _, _,
-//                 X, _, X, X, _, _, _, X, _, _, _, X, _, X, X, X, _, X,
-//                 _, X, X, X, X, _, _, _, _, X, _, _, X, _, X, _, _, _,
-//                 _, X, _, _, _, X, _, _, _, X, _, _, _, _, X, _, _, _};
-//
-//    geometry_msgs::Point start;
-//    start.x = 0.0;
-//    start.y = 0.0;
-//    geometry_msgs::Point goal;
-//    goal.x = 0.0;
-//    goal.y = 8.0;
-//
-//    nav_msgs::Path path = PathFinder::calculatePath(start, goal, grid);
-//
-//    ASSERT_EQ(path.poses.size(), 9);
-//
-//    std::vector<float> expected_x = {
-//    0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 1.0, 0.0, 0.0};
-//    std::vector<float> expected_y = {
-//    0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0};
-//
-//    for (int i = 0; i < path.poses.size(); i++) {
-//        EXPECT_FLOAT_EQ(expected_x[i], path.poses[i].pose.position.x);
-//        EXPECT_FLOAT_EQ(expected_y[i], path.poses[i].pose.position.y);
-//    }
-//}
+ TEST(PathFinder, TestFullPath) {
+    /* origin of OccupancyGrid */
+    // initialize origin of occupancy grid
+    geometry_msgs::Pose origin =
+    PathFinderTestUtils::constructPose(0.0, 0.0, 0.0);
+
+    /* mapMetaData of OccupancyGrid */
+    // initialize mapMetaData
+    nav_msgs::MapMetaData mapMetaData;
+    mapMetaData.resolution = 1.0;
+    mapMetaData.width      = 10;
+    mapMetaData.height     = 9;
+    // add origin to mapMetaData
+    mapMetaData.origin = origin;
+
+    /* OccupancyGrid */
+    // initialize occupancy grid
+    nav_msgs::OccupancyGrid grid;
+
+    // set mapMetaData
+    grid.info = mapMetaData;
+    grid.data = {_, _, _, X, X, X, _, X, X, _, _, X, _, _, _, _, X, _,
+                 _, _, _, X, X, X, X, _, X, X, X, _, _, X, _, _, _, _,
+                 X, _, X, X, _, _, _, X, _, _, _, X, _, X, X, X, _, X,
+                 _, X, X, X, X, _, _, _, _, X, _, _, X, _, X, _, _, _,
+                 _, X, _, _, _, X, _, _, _, X, _, _, _, _, X, _, _, _};
+
+    geometry_msgs::Point start;
+    start.x = 0.0;
+    start.y = 0.0;
+    geometry_msgs::Point goal;
+    goal.x = 0.0;
+    goal.y = 8.0;
+
+    nav_msgs::Path path = PathFinder::calculatePath(start, goal, grid);
+
+    ASSERT_EQ(path.poses.size(), 9);
+
+    std::vector<float> expected_x = {
+    0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 1.0, 0.0, 0.0};
+    std::vector<float> expected_y = {
+    0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0};
+
+    for (int i = 0; i < path.poses.size(); i++) {
+        EXPECT_FLOAT_EQ(expected_x[i], path.poses[i].pose.position.x);
+        EXPECT_FLOAT_EQ(expected_y[i], path.poses[i].pose.position.y);
+    }
+}
 
 // TODO: Uncomment and fix, see issue #339
-// TEST(PathFinder, PathFindingWhenGoalNotInGrid) {
-//    /* origin of OccupancyGrid */
-//    // initialize origin of occupancy grid
-//    geometry_msgs::Pose origin =
-//    PathFinderTestUtils::constructPose(3.0, 3.0, 0.0);
-//
-//    /* map_meta_data of OccupancyGrid */
-//    // initialize map_meta_data
-//    nav_msgs::MapMetaData map_meta_data;
-//    map_meta_data.resolution = 2.0;
-//    map_meta_data.width      = 2;
-//    map_meta_data.height     = 3;
-//    // add origin to map_meta_data
-//    map_meta_data.origin = origin;
-//
-//    /* OccupancyGrid */
-//    // initialize occupancy grid
-//    nav_msgs::OccupancyGrid grid;
-//    // set map_meta_data
-//    grid.info = map_meta_data;
-//    grid.data = {
-//    X, X, X, X, _, _,
-//    };
-//
-//    /* Starting point in map frame */
-//    geometry_msgs::Point start;
-//    start.x = 3.0;
-//    start.y = 7.0;
-//
-//    /* Goal point in map frame */
-//    geometry_msgs::Point goal;
-//    goal.x = 3.0;
-//    goal.y = -9999;
-//
-//    nav_msgs::Path path = PathFinder::calculatePath(start, goal, grid);
-//
-//    EXPECT_EQ(path.poses.size(), 4);
-//
-//    std::vector<float> expected_x = {3.0, 1.0, 1.0, 3.0};
-//    std::vector<float> expected_y = {7.0, 5.0, 3.0, 1.0};
-//    for (int i = 0; i < path.poses.size(); i++) {
-//        EXPECT_FLOAT_EQ(expected_x[i], path.poses[i].pose.position.x);
-//        EXPECT_FLOAT_EQ(expected_y[i], path.poses[i].pose.position.y);
-//    }
-//}
+ TEST(PathFinder, PathFindingWhenGoalNotInGrid) {
+    /* origin of OccupancyGrid */
+    // initialize origin of occupancy grid
+    geometry_msgs::Pose origin =
+    PathFinderTestUtils::constructPose(3.0, 3.0, 0.0);
+
+    /* map_meta_data of OccupancyGrid */
+    // initialize map_meta_data
+    nav_msgs::MapMetaData map_meta_data;
+    map_meta_data.resolution = 2.0;
+    map_meta_data.width      = 2;
+    map_meta_data.height     = 3;
+    // add origin to map_meta_data
+    map_meta_data.origin = origin;
+
+    /* OccupancyGrid */
+    // initialize occupancy grid
+    nav_msgs::OccupancyGrid grid;
+    // set map_meta_data
+    grid.info = map_meta_data;
+    grid.data = {
+    X, X, X, X, _, _,
+    };
+
+    /* Starting point in map frame */
+    geometry_msgs::Point start;
+    start.x = 3.0;
+    start.y = 7.0;
+
+    /* Goal point in map frame */
+    geometry_msgs::Point goal;
+    goal.x = 3.0;
+    goal.y = -9999;
+
+    nav_msgs::Path path = PathFinder::calculatePath(start, goal, grid);
+
+    EXPECT_EQ(path.poses.size(), 4);
+
+    std::vector<float> expected_x = {3.0, 1.0, 1.0, 3.0};
+    std::vector<float> expected_y = {7.0, 5.0, 3.0, 1.0};
+    for (int i = 0; i < path.poses.size(); i++) {
+        EXPECT_FLOAT_EQ(expected_x[i], path.poses[i].pose.position.x);
+        EXPECT_FLOAT_EQ(expected_y[i], path.poses[i].pose.position.y);
+    }
+}
 
 TEST(PathFinder, ProcessGridAndGetStartAndGoalOnGrid) {
     /* origin of OccupancyGrid */


### PR DESCRIPTION
Uncommenting broken tests from #328 

Issue was that the pointer to `OccupancyGridAdapter` in `PathConstructor` got corrupted. So I changed it so that `PathConstructor` takes in a pointer of `OccupancyGridAdapter` instead of an instance/object of it and storing its reference. This would force whoever is calling `PathConstructor` to deal with `OccupancyGridAdapter`'s pointer.  