### PR TITLE
Dual cameras

### DIFF
--- a/.rosinstall
+++ b/.rosinstall
@@ -2,13 +2,11 @@
     local-name: src/external_pkgs/nmea_navsat_driver
     uri: https://github.com/UBC-Snowbots/nmea_navsat_driver.git
 - git:
-    local-name: src/external_pkgs/realsense
-    uri: https://github.com/intel-ros/realsense.git
-    version: 2.0.4
+    local-name: src/external_pkgs/realsense-ros
+    uri: https://github.com/IntelRealSense/realsense-ros.git
 - git:
     local-name: external_libs/librealsense
     uri: https://github.com/IntelRealsense/librealsense.git
-    version: v2.16.0
 - git:
     local-name: src/external_pkgs/ros_arduino_bridge
     uri: https://github.com/UBC-Snowbots/ros_arduino_bridge.git

--- a/src/cameras/CAMERAS.md
+++ b/src/cameras/CAMERAS.md
@@ -1,0 +1,19 @@
+# Cameras
+This package is implemented in 2021 to view both Intel cameras that UBC Snowbots owns: the Intel Realsense D415 and D435i
+
+The serial number of the D415 is 739112061033
+
+The serial number of the D435i is 116622072291
+
+These serial numbers are reflected in the launch files in this directory. 
+
+The launch files simply call the launch file from external_pkgs/realsense2_camera with specific argments
+
+Running it without argments would connect to the first realsense camera found, but to connect to two those argments
+need to be specified.
+
+Both cameras can be launched using realsense_both.launch.
+
+Lastly, camera_viewer.launch is a file that is supposed to work with any usb camera, copied from the internet. 
+For the realsense cameras, it's probably better to use the ros wrapper as above, but for a new camera it might be worth
+trying the camera_viewer.launch. 

--- a/src/cameras/CMakeLists.txt
+++ b/src/cameras/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(cameras)
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+endif()
+
+add_definitions(-std=c++14)
+
+find_package(catkin REQUIRED COMPONENTS
+        roscpp
+        geometry_msgs
+        )
+find_package(sb_utils REQUIRED)
+
+
+catkin_package(
+        INCLUDE_DIRS include
+        CATKIN_DEPENDS roscpp geometry_msgs
+)
+
+include_directories(
+        ${catkin_INCLUDE_DIRS}
+        ${sb_utils_INCLUDE_DIRS}
+        ./include
+)

--- a/src/cameras/CMakeLists.txt
+++ b/src/cameras/CMakeLists.txt
@@ -11,7 +11,6 @@ find_package(catkin REQUIRED COMPONENTS
         roscpp
         geometry_msgs
         )
-find_package(sb_utils REQUIRED)
 
 
 catkin_package(

--- a/src/cameras/CMakeLists.txt
+++ b/src/cameras/CMakeLists.txt
@@ -15,12 +15,5 @@ find_package(sb_utils REQUIRED)
 
 
 catkin_package(
-        INCLUDE_DIRS include
         CATKIN_DEPENDS roscpp geometry_msgs
-)
-
-include_directories(
-        ${catkin_INCLUDE_DIRS}
-        ${sb_utils_INCLUDE_DIRS}
-        ./include
 )

--- a/src/cameras/launch/camera_viewer.launch
+++ b/src/cameras/launch/camera_viewer.launch
@@ -1,0 +1,19 @@
+<!-- This launch file might work for generic USB cameras, but for our zed camera it doesn't work and for our realsense camera there -->
+<!-- is another launch file that comes from the realsense2_camera package that is better. -->
+<!-- Run using "roslaunch cameras camera_viewer.launch videonum:=0" to use your webcam, see using "rosrun rqt_image_view
+rqt_image_view" and selecting /usb_cam/image_raw -->
+<launch>
+  <arg name="videonum" />
+  <node name="usb_cam" pkg="usb_cam" type="usb_cam_node" output="screen" >
+    <param name="video_device" value="/dev/video$(arg videonum)" />
+    <param name="image_width" value="640" />
+    <param name="image_height" value="480" />
+    <param name="pixel_format" value="yuyv" />
+    <param name="camera_frame_id" value="usb_cam" />
+    <param name="io_method" value="mmap"/>
+  </node>
+  <node name="image_view" pkg="image_view" type="image_view" respawn="false" output="screen">
+    <remap from="image" to="/usb_cam$(arg videonum)/image_raw"/>
+    <param name="autosize" value="true" />
+  </node>
+</launch>

--- a/src/cameras/launch/realsense.launch
+++ b/src/cameras/launch/realsense.launch
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<launch>
+
+  <include file="./src/external_pkgs/realsense/realsense2_camera/launch/rs_camera.launch" />
+
+</launch>

--- a/src/cameras/launch/realsense.launch
+++ b/src/cameras/launch/realsense.launch
@@ -1,7 +1,0 @@
-<?xml version="1.0"?>
-
-<launch>
-
-  <include file="./src/external_pkgs/realsense/realsense2_camera/launch/rs_camera.launch" />
-
-</launch>

--- a/src/cameras/launch/realsense_both.launch
+++ b/src/cameras/launch/realsense_both.launch
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+
+<launch>
+
+     <include file="$(find realsense2_camera)/launch/rs_camera.launch">
+           <arg name="camera" value="cam_1"/>
+           <arg name="serial_no" value="739112061033" />
+     </include>
+
+     <include file="$(find realsense2_camera)/launch/rs_camera.launch">
+          <arg name="camera" value="cam_2"/>
+          <arg name="serial_no" value="116622072291" />
+     </include>
+
+    <node name="viewer1" pkg="rqt_image_view" type="rqt_image_view" />
+    <node name="viewer2" pkg="rqt_image_view" type="rqt_image_view" />
+
+</launch>

--- a/src/cameras/launch/realsense_both.launch
+++ b/src/cameras/launch/realsense_both.launch
@@ -12,7 +12,7 @@
           <arg name="serial_no" value="116622072291" />
      </include>
 
-    <node name="viewer1" pkg="rqt_image_view" type="rqt_image_view" />
-    <node name="viewer2" pkg="rqt_image_view" type="rqt_image_view" />
+    <node name="viewer1" pkg="rqt_image_view" type="rqt_image_view" args="/cam_1/color/image_raw"/>
+    <node name="viewer2" pkg="rqt_image_view" type="rqt_image_view" args="/cam_2/color/image_raw"/>
 
 </launch>

--- a/src/cameras/launch/realsense_d415.launch
+++ b/src/cameras/launch/realsense_d415.launch
@@ -6,6 +6,6 @@
       <arg name="camera" value="cam_1"/>
       <arg name="serial_no" value="739112061033" />
     </include>
-    <node name="viewer1" pkg="rqt_image_view" type="rqt_image_view" />
+    <node name="viewer1" pkg="rqt_image_view" type="rqt_image_view"  args="/cam_1/color/image_raw" />
 
 </launch>

--- a/src/cameras/launch/realsense_d415.launch
+++ b/src/cameras/launch/realsense_d415.launch
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<launch>
+
+    <include file="$(find realsense2_camera)/launch/rs_camera.launch">
+      <arg name="camera" value="cam_1"/>
+      <arg name="serial_no" value="739112061033" />
+    </include>
+    <node name="viewer1" pkg="rqt_image_view" type="rqt_image_view" />
+
+</launch>

--- a/src/cameras/launch/realsense_d435i.launch
+++ b/src/cameras/launch/realsense_d435i.launch
@@ -6,6 +6,6 @@
       <arg name="camera" value="cam_2"/>
       <arg name="serial_no" value="116622072291" />
     </include>
-    <node name="viewer1" pkg="rqt_image_view" type="rqt_image_view" />
+    <node name="viewer1" pkg="rqt_image_view" type="rqt_image_view" args="/cam_2/color/image_raw"/>
 
 </launch>

--- a/src/cameras/launch/realsense_d435i.launch
+++ b/src/cameras/launch/realsense_d435i.launch
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<launch>
+
+    <include file="$(find realsense2_camera)/launch/rs_camera.launch">
+      <arg name="camera" value="cam_2"/>
+      <arg name="serial_no" value="116622072291" />
+    </include>
+    <node name="viewer1" pkg="rqt_image_view" type="rqt_image_view" />
+
+</launch>

--- a/src/cameras/package.xml
+++ b/src/cameras/package.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<package>
+  <name>cameras</name>
+  <version>0.0.0</version>
+  <description>The two cameras package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="Kevin@todo.todo">Kevin</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/challenge</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>std_msgs</run_depend>
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/src/cameras/package.xml
+++ b/src/cameras/package.xml
@@ -4,41 +4,10 @@
   <version>0.0.0</version>
   <description>The two cameras package</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="Kevin@todo.todo">Kevin</maintainer>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>TODO</license>
 
-
-  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/challenge</url> -->
-
-
-  <!-- Author tags are optional, mutiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintianers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *_depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use run_depend for packages you need at runtime: -->
-  <!--   <run_depend>message_runtime</run_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>roscpp</build_depend>
@@ -47,9 +16,7 @@
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
 
-  <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <!-- Other tools can request additional information be placed here -->
 
   </export>
 </package>


### PR DESCRIPTION
<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description
Adds launch files for the two intel cameras, and makes the installation of the intel realsense sdk and ros wrapper automatically the highest version. 

### Testing Done
Running `roslaunch cameras realsense_d435i.launch` streams our d435i camera to a rqt_image_view window automatically
Running `roslaunch cameras realsense_d415.launch` does the same
Running `roslaunch cameras realsense_both.launch` creates two rqt_image_view windows and streams both cameras.

If any number of cameras aren't plugged in, the node doesn't crash, rather it does nothing until a camera is plugged in.



